### PR TITLE
Add 'role_name' output variable

### DIFF
--- a/aws_iam_role.pipeline.tf
+++ b/aws_iam_role.pipeline.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "pipeline" {
   count = var.role_arn == "" ? 1 : 0
-  name  = "AWSCodePipelineServiceRole-${data.aws_region.current.name}-${var.name}"
+  name  = local.role_name
   path  = "/service-role/"
 
   assume_role_policy = <<POLICY

--- a/aws_iam_role_policy.inline_policy.tf
+++ b/aws_iam_role_policy.inline_policy.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role_policy" "inline_policy" {
   count = var.role_arn == "" ? 1 : 0
-  name  = "AWSCodePipeline-${data.aws_region.current.name}-${var.name}"
+  name  = local.role_name
   role  = aws_iam_role.pipeline.0.name
 
   policy = data.aws_iam_policy_document.pipeline.json

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 
 locals {
   role_arn = var.role_arn == "" ? aws_iam_role.pipeline.0.arn : var.role_arn
+  role_name = var.role_arn == "" ? "AWSCodePipelineServiceRole-${data.aws_region.current.name}-${var.name}" : ""
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "role_arn" {
   description = "ARN of the pipeline role"
   value       = local.role_arn
 }
+
+output "role_name" {
+  description = "Name of the pipeline role created if var.role_arn is not supplied"
+  value       = local.role_name
+}


### PR DESCRIPTION
In order to attach an additional policy to the role created by this module, we need the role name, not the ARN. Even if it is technically possible to extract role name from role ARN, it is cleaner to output the value.

AS role name is output, role ARN output could be removed because aws_iam_role data source allows to get ARN from name, but it will be kept for backwards compatibility.